### PR TITLE
Show login page before index

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,11 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>S2 Code Team - Kết Nối Cộng Đồng</title>
   <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;700&display=swap" rel="stylesheet">
+  <script>
+    if (!localStorage.getItem('adminToken')) {
+      window.location.href = 'login.html';
+    }
+  </script>
   <style>
     * {
       margin: 0;


### PR DESCRIPTION
## Summary
- add a small script in `index.html` to redirect visitors to `login.html` if they have not logged in

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_68459f90ccdc8322b23cde5740fe8981